### PR TITLE
Update help text for "create cph"

### DIFF
--- a/pkg/cmd/create/clusterpoolhost/cmd.go
+++ b/pkg/cmd/create/clusterpoolhost/cmd.go
@@ -14,7 +14,7 @@ import (
 
 var example = `
 # Initialize a clusterpool management cluster
-%[1]s create cph <clusterpoolhosts_name> --apiserver-url <cluster_api_server_url> --console <cluster_console_url> --group <user_group> --namespace <namespace>
+%[1]s create cph <clusterpoolhosts_name> --api-server <cluster_api_server_url> --console <cluster_console_url> --group <user_group> --namespace <namespace>
 `
 
 // var valuesDefaultPath = filepath.Join(scenarioDirectory, "values-default.yaml")


### PR DESCRIPTION
create cph takes an argument of `--api-server` but the help text example uses `--apiserver-url` leading to the following error:
```
$ cm create cph <clusterpoolhost-name> --apiserver-url <api-url> --console <console-url> --group=<group> --namespace=<namespace>
Error: unknown flag: --apiserver-url
```