### PR TITLE
Fix crash `cm run cc xxx` as  no printFlag

### DIFF
--- a/pkg/clusterpoolhost/clusterclaim.go
+++ b/pkg/clusterpoolhost/clusterclaim.go
@@ -252,7 +252,7 @@ func checkClusterClaimsRunning(dynamicClient dynamic.Interface, clusterClaimName
 					len(cd.Status.APIURL) != 0 &&
 					c != nil && c.Status == corev1.ConditionStatus(metav1.ConditionTrue) {
 					running = true
-					if printFlags.OutputFormat == nil || strings.HasPrefix(*printFlags.OutputFormat, "custom-columns=") {
+					if printFlags == nil || printFlags.OutputFormat == nil || strings.HasPrefix(*printFlags.OutputFormat, "custom-columns=") {
 						fmt.Printf("clusterclaim %s is running with id %s (%d/%d)\n", clusterClaimName, cc.Spec.Namespace, i, timeout)
 					}
 				}


### PR DESCRIPTION
Signed-off-by: Dominique Vernier <dvernier@redhat.com>