### PR TITLE
Update doc output; Don't use printer when output is specified

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ build:
 	go install ./cmd/cm.go
 
 .PHONY: build-bin
-build-bin: doc-help doc-clean
+build-bin: doc-help
 	tar -czf docs/help.tar.gz -C docs/help/ .
 	zip -q docs/help.zip -j docs/help/*
 	@rm -rf bin
@@ -48,9 +48,6 @@ doc-help:
 	@echo "Generate help markdown in docs/help"
 	go build -o docs/tools/cm docs/tools/cm.go && PATH=docs/tools cm && rm docs/tools/cm
 	@echo "Markdown generated"
-
-.PHONY: doc-clean
-doc-clean:
 	@build/clean-docs.sh
 
 .PHONY: install

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,8 @@ build:
 	rm -f ${GOPATH}/bin/cm
 	go install ./cmd/cm.go
 
-.PHONY: 
-build-bin: doc-help
+.PHONY: build-bin
+build-bin: doc-help doc-clean
 	tar -czf docs/help.tar.gz -C docs/help/ .
 	zip -q docs/help.zip -j docs/help/*
 	@rm -rf bin
@@ -43,11 +43,15 @@ build-bin: doc-help
 	GOOS=linux GOARCH=s390x go build -ldflags="-s -w" -gcflags=-trimpath=x/y  -o bin/cm ./cmd/cm.go && tar -czf bin/cm_linux_s390x.tar.gz -C bin/ cm
 	GOOS=windows GOARCH=amd64 go build -ldflags="-s -w" -gcflags=-trimpath=x/y  -o bin/cm.exe ./cmd/cm.go && zip -q bin/cm_windows_amd64.zip -j bin/cm.exe
 
-,PHONY: doc-help
+.PHONY: doc-help
 doc-help:
 	@echo "Generate help markdown in docs/help"
 	go build -o docs/tools/cm docs/tools/cm.go && PATH=docs/tools cm && rm docs/tools/cm
 	@echo "Markdown generated"
+
+.PHONY: doc-clean
+doc-clean:
+	@build/clean-docs.sh
 
 .PHONY: install
 install: build

--- a/build/clean-docs.sh
+++ b/build/clean-docs.sh
@@ -1,0 +1,20 @@
+#! /bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# Fix sed issues on Mac by using gsed
+SED="sed"
+if [ "${OS}" == "darwin" ]; then
+    SED="gsed"
+    if [ ! -x "$(command -v ${SED})"  ]; then
+       echo "ERROR: ${SED} required, but not found."
+       echo "Perform \"brew install gnu-sed\" and try again."
+       exit 1
+    fi
+fi
+
+echo "##### Cleaning doc files"
+echo "* Replacing '${HOME}' with '\${HOME}'"
+for FILE in $(grep -rl "${HOME}" ${DIR}/../docs); do 
+  ${SED} -i 's%'${HOME}'%${HOME}%g' ${FILE}
+done

--- a/build/clean-docs.sh
+++ b/build/clean-docs.sh
@@ -4,6 +4,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 # Fix sed issues on Mac by using gsed
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 SED="sed"
 if [ "${OS}" == "darwin" ]; then
     SED="gsed"

--- a/build/clean-docs.sh
+++ b/build/clean-docs.sh
@@ -1,4 +1,5 @@
 #! /bin/bash
+# Copyright Contributors to the Open Cluster Management project
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 

--- a/build/clean-docs.sh
+++ b/build/clean-docs.sh
@@ -15,7 +15,7 @@ if [ "${OS}" == "darwin" ]; then
     fi
 fi
 
-echo "##### Cleaning doc files"
+echo "Cleaning doc files:"
 echo "* Replacing '${HOME}' with '\${HOME}'"
 for FILE in $(grep -rl "${HOME}" ${DIR}/../docs); do 
   ${SED} -i 's%'${HOME}'%${HOME}%g' ${FILE}

--- a/docs/help/cm.md
+++ b/docs/help/cm.md
@@ -10,7 +10,7 @@ CLI for Red Hat Advanced Clust Management
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_accept.md
+++ b/docs/help/cm_accept.md
@@ -31,7 +31,7 @@ cm accept --clusters <cluster_1>,<cluster_2>,...
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_attach.md
+++ b/docs/help/cm_attach.md
@@ -16,7 +16,7 @@ attach a resource
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_attach_cluster.md
+++ b/docs/help/cm_attach_cluster.md
@@ -41,7 +41,7 @@ cm attach cluster mycluster --values values.yaml
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_attach_clusterclaim.md
+++ b/docs/help/cm_attach_clusterclaim.md
@@ -35,7 +35,7 @@ cm attach cc --values values.yaml --cph <clusterpoolhost_name>
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_console.md
+++ b/docs/help/cm_console.md
@@ -16,7 +16,7 @@ open a console
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_console_clusterclaims.md
+++ b/docs/help/cm_console_clusterclaims.md
@@ -34,7 +34,7 @@ cm console clusterclaims
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_console_clusterpoolhost.md
+++ b/docs/help/cm_console_clusterpoolhost.md
@@ -30,7 +30,7 @@ cm console cph <clusterpoolhost_name>
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_create.md
+++ b/docs/help/cm_create.md
@@ -16,7 +16,7 @@ create a resource
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_create_cluster.md
+++ b/docs/help/cm_create_cluster.md
@@ -37,7 +37,7 @@ cm create cluster mycluster --values values.yaml
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_create_clusterclaim.md
+++ b/docs/help/cm_create_clusterclaim.md
@@ -36,7 +36,7 @@ cm create cc <clusterpool> <clusterclaim_name>[,<clusterclaim_name>...] --cph <c
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_create_clusterpool.md
+++ b/docs/help/cm_create_clusterpool.md
@@ -35,7 +35,7 @@ cm create cp [<clusterpool_name>] --values values.yaml [--cph <clusterpoolhost_n
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_create_clusterpoolhost.md
+++ b/docs/help/cm_create_clusterpoolhost.md
@@ -34,7 +34,7 @@ cm create cph <clusterpoolhosts_name> --api-server <cluster_api_server_url> --co
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_delete.md
+++ b/docs/help/cm_delete.md
@@ -16,7 +16,7 @@ delete a resource
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_delete_cluster.md
+++ b/docs/help/cm_delete_cluster.md
@@ -36,7 +36,7 @@ cm delete cluster mycluster--values values.yaml
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_delete_clusterclaim.md
+++ b/docs/help/cm_delete_clusterclaim.md
@@ -33,7 +33,7 @@ cm delete cc <clusterclaim_name>[,<clusterclaim_name>...] -cph <clusterpoolhost_
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_delete_clusterpool.md
+++ b/docs/help/cm_delete_clusterpool.md
@@ -33,7 +33,7 @@ cm delete cp <clusterpool_name>[,<clusterpool_name>...] -cph <clusterpoolhost_na
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_delete_clusterpoolhost.md
+++ b/docs/help/cm_delete_clusterpoolhost.md
@@ -29,7 +29,7 @@ cm delete clusterpoolhosts
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_delete_token.md
+++ b/docs/help/cm_delete_token.md
@@ -29,7 +29,7 @@ cm delete token
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_detach.md
+++ b/docs/help/cm_detach.md
@@ -16,7 +16,7 @@ detach a resources
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_detach_cluster.md
+++ b/docs/help/cm_detach_cluster.md
@@ -36,7 +36,7 @@ cm detach cluster mycluster --values values.yaml
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_enable.md
+++ b/docs/help/cm_enable.md
@@ -16,7 +16,7 @@ enable a feature
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_enable_addons.md
+++ b/docs/help/cm_enable_addons.md
@@ -34,7 +34,7 @@ cm enable addons --values values.yaml --cluster mycluster
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_get.md
+++ b/docs/help/cm_get.md
@@ -16,7 +16,7 @@ get a resource
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS
@@ -57,5 +57,6 @@ get a resource
 * [cm get config](cm_get_config.md)	 - get the config of a resource
 * [cm get credentials](cm_get_credentials.md)	 - list the credentials of cloud providers
 * [cm get machinepools](cm_get_machinepools.md)	 - list the machinepools for a give cluster
+* [cm get policies](cm_get_policies.md)	 - Display policies
 * [cm get token](cm_get_token.md)	 - get the bootsrap token
 

--- a/docs/help/cm_get_clusterclaims.md
+++ b/docs/help/cm_get_clusterclaims.md
@@ -47,7 +47,7 @@ cm get clusterclaims
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_get_clusterpoolhosts.md
+++ b/docs/help/cm_get_clusterpoolhosts.md
@@ -38,7 +38,7 @@ cm get cph
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_get_clusterpools.md
+++ b/docs/help/cm_get_clusterpools.md
@@ -46,7 +46,7 @@ cm get cp <clusterpool_name> -A
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_get_clusters.md
+++ b/docs/help/cm_get_clusters.md
@@ -48,7 +48,7 @@ cm get clusters [(-o|--output=)json|yaml|wide|custom-columns=...|custom-columns-
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_get_config.md
+++ b/docs/help/cm_get_config.md
@@ -16,7 +16,7 @@ get the config of a resource
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_get_config_cluster.md
+++ b/docs/help/cm_get_config_cluster.md
@@ -32,7 +32,7 @@ cm get config cluster
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_get_config_clusterpool.md
+++ b/docs/help/cm_get_config_clusterpool.md
@@ -33,7 +33,7 @@ cm get config clusterpool
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_get_credentials.md
+++ b/docs/help/cm_get_credentials.md
@@ -50,7 +50,7 @@ cm get credentials [(-o|--output=)json|yaml|wide|custom-columns=...|custom-colum
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_get_machinepools.md
+++ b/docs/help/cm_get_machinepools.md
@@ -49,7 +49,7 @@ cm get machinepools [(-o|--output=)json|yaml|wide|custom-columns=...|custom-colu
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_get_policies.md
+++ b/docs/help/cm_get_policies.md
@@ -52,7 +52,7 @@ cm get policies [(-o|--output=)json|yaml|wide|custom-columns=...|custom-columns-
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dhaiduce/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_get_token.md
+++ b/docs/help/cm_get_token.md
@@ -31,7 +31,7 @@ cm get token
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_hibernate.md
+++ b/docs/help/cm_hibernate.md
@@ -16,7 +16,7 @@ hibernate a resource
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_hibernate_clusterclaim.md
+++ b/docs/help/cm_hibernate_clusterclaim.md
@@ -35,7 +35,7 @@ cm hibernate cc <clusterclaim_name>[,<clusterclaim_name>...] --cph <clusterpoolh
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_init.md
+++ b/docs/help/cm_init.md
@@ -32,7 +32,7 @@ cm init
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_join.md
+++ b/docs/help/cm_join.md
@@ -33,7 +33,7 @@ cm join --hub-token <tokenID.tokenSecret> --hub-apiserver <hub_apiserveR_url> --
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_options.md
+++ b/docs/help/cm_options.md
@@ -31,7 +31,7 @@ cm options [flags]
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_plugin.md
+++ b/docs/help/cm_plugin.md
@@ -28,7 +28,7 @@ cm plugin [flags]
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_plugin_list.md
+++ b/docs/help/cm_plugin_list.md
@@ -27,7 +27,7 @@ cm plugin list [flags]
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_run.md
+++ b/docs/help/cm_run.md
@@ -16,7 +16,7 @@ run a resource
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_run_clusterclaim.md
+++ b/docs/help/cm_run_clusterclaim.md
@@ -36,7 +36,7 @@ cm run cc <clusterclaim_name>[,<clusterclaim_name>...] --cph <clusterpoolhost> <
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_scale.md
+++ b/docs/help/cm_scale.md
@@ -16,7 +16,7 @@ scale a resource
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_scale_cluster.md
+++ b/docs/help/cm_scale_cluster.md
@@ -31,7 +31,7 @@ cm scale cluster --cluster clustername --machinepool poolname --replicas 4
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_scale_clusterpool.md
+++ b/docs/help/cm_scale_clusterpool.md
@@ -34,7 +34,7 @@ cm scale cp <clusterpool_name> --size <size> --cph <clusterpoolhost> <options>
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_set.md
+++ b/docs/help/cm_set.md
@@ -16,7 +16,7 @@ set a resource
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_set_clusterpoolhost.md
+++ b/docs/help/cm_set_clusterpoolhost.md
@@ -29,7 +29,7 @@ cm set cph clusterpoolhost
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_use.md
+++ b/docs/help/cm_use.md
@@ -16,7 +16,7 @@ use a resource
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_use_clusterclaim.md
+++ b/docs/help/cm_use_clusterclaim.md
@@ -38,7 +38,7 @@ cm use cc <cluster_claim_name> --cph <cluster_pool_host_name>
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_use_clusterpoolhost.md
+++ b/docs/help/cm_use_clusterpoolhost.md
@@ -29,7 +29,7 @@ cm use clusterpoolhost|cph clusterpoolhost
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_version.md
+++ b/docs/help/cm_version.md
@@ -29,7 +29,7 @@ cm version
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_with.md
+++ b/docs/help/cm_with.md
@@ -16,7 +16,7 @@ execute a command on a specific cluster
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS

--- a/docs/help/cm_with_clusterclaim.md
+++ b/docs/help/cm_with_clusterclaim.md
@@ -38,7 +38,7 @@ cm with cc <cluster_claim_name> --cph <cluster_pool_host_name>
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --beta                             If set commands or functionalities in beta version will be available
-      --cache-dir string                 Default cache directory (default "/Users/dvernier/.kube/cache")
+      --cache-dir string                 Default cache directory (default "${HOME}/.kube/cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS


### PR DESCRIPTION
I'm not sure about the Makefile changes (it seemed like `,PHONY` starting with a comma wasn't going to do anything?), but I've added a script to replace `${HOME}` in the docs which should make the docs more generic, consistent, and prevent unexpected updates.

I also think that if a user specifies `-o`, I'd prefer to print the actual policy YAML rather than the printer YAML, so this also addresses that.