### PR TITLE
Fix typo

### DIFF
--- a/docs/help/cm.md
+++ b/docs/help/cm.md
@@ -1,6 +1,6 @@
 ## cm
 
-CLI for Red Hat Advanced Clust Management
+CLI for Open Cluster Management
 
 ### Options
 

--- a/docs/help/cm.md
+++ b/docs/help/cm.md
@@ -1,6 +1,6 @@
 ## cm
 
-CLI for Open Cluster Management
+CLI for Red Hat Advanced Cluster Management
 
 ### Options
 

--- a/docs/help/cm_accept.md
+++ b/docs/help/cm_accept.md
@@ -64,5 +64,5 @@ cm accept --clusters <cluster_1>,<cluster_2>,...
 
 ### SEE ALSO
 
-* [cm](cm.md)	 - CLI for Open Cluster Management
+* [cm](cm.md)	 - CLI for Red Hat Advanced Cluster Management
 

--- a/docs/help/cm_accept.md
+++ b/docs/help/cm_accept.md
@@ -64,5 +64,5 @@ cm accept --clusters <cluster_1>,<cluster_2>,...
 
 ### SEE ALSO
 
-* [cm](cm.md)	 - CLI for Red Hat Advanced Clust Management
+* [cm](cm.md)	 - CLI for Open Cluster Management
 

--- a/docs/help/cm_attach.md
+++ b/docs/help/cm_attach.md
@@ -49,7 +49,7 @@ attach a resource
 
 ### SEE ALSO
 
-* [cm](cm.md)	 - CLI for Open Cluster Management
+* [cm](cm.md)	 - CLI for Red Hat Advanced Cluster Management
 * [cm attach cluster](cm_attach_cluster.md)	 - Import a cluster
 * [cm attach clusterclaim](cm_attach_clusterclaim.md)	 - Import a clusterclaim
 

--- a/docs/help/cm_attach.md
+++ b/docs/help/cm_attach.md
@@ -49,7 +49,7 @@ attach a resource
 
 ### SEE ALSO
 
-* [cm](cm.md)	 - CLI for Red Hat Advanced Clust Management
+* [cm](cm.md)	 - CLI for Open Cluster Management
 * [cm attach cluster](cm_attach_cluster.md)	 - Import a cluster
 * [cm attach clusterclaim](cm_attach_clusterclaim.md)	 - Import a clusterclaim
 

--- a/docs/help/cm_console.md
+++ b/docs/help/cm_console.md
@@ -49,7 +49,7 @@ open a console
 
 ### SEE ALSO
 
-* [cm](cm.md)	 - CLI for Red Hat Advanced Clust Management
+* [cm](cm.md)	 - CLI for Open Cluster Management
 * [cm console clusterclaims](cm_console_clusterclaims.md)	 - Open console of a clusterclaim
 * [cm console clusterpoolhost](cm_console_clusterpoolhost.md)	 - open the console of a clusterpoolhost
 

--- a/docs/help/cm_console.md
+++ b/docs/help/cm_console.md
@@ -49,7 +49,7 @@ open a console
 
 ### SEE ALSO
 
-* [cm](cm.md)	 - CLI for Open Cluster Management
+* [cm](cm.md)	 - CLI for Red Hat Advanced Cluster Management
 * [cm console clusterclaims](cm_console_clusterclaims.md)	 - Open console of a clusterclaim
 * [cm console clusterpoolhost](cm_console_clusterpoolhost.md)	 - open the console of a clusterpoolhost
 

--- a/docs/help/cm_create.md
+++ b/docs/help/cm_create.md
@@ -49,7 +49,7 @@ create a resource
 
 ### SEE ALSO
 
-* [cm](cm.md)	 - CLI for Red Hat Advanced Clust Management
+* [cm](cm.md)	 - CLI for Open Cluster Management
 * [cm create cluster](cm_create_cluster.md)	 - Create a cluster
 * [cm create clusterclaim](cm_create_clusterclaim.md)	 - Create clusterclaims
 * [cm create clusterpool](cm_create_clusterpool.md)	 - Create a clusterpool

--- a/docs/help/cm_create.md
+++ b/docs/help/cm_create.md
@@ -49,7 +49,7 @@ create a resource
 
 ### SEE ALSO
 
-* [cm](cm.md)	 - CLI for Open Cluster Management
+* [cm](cm.md)	 - CLI for Red Hat Advanced Cluster Management
 * [cm create cluster](cm_create_cluster.md)	 - Create a cluster
 * [cm create clusterclaim](cm_create_clusterclaim.md)	 - Create clusterclaims
 * [cm create clusterpool](cm_create_clusterpool.md)	 - Create a clusterpool

--- a/docs/help/cm_delete.md
+++ b/docs/help/cm_delete.md
@@ -49,7 +49,7 @@ delete a resource
 
 ### SEE ALSO
 
-* [cm](cm.md)	 - CLI for Red Hat Advanced Clust Management
+* [cm](cm.md)	 - CLI for Open Cluster Management
 * [cm delete cluster](cm_delete_cluster.md)	 - Delete a cluster
 * [cm delete clusterclaim](cm_delete_clusterclaim.md)	 - Delete clusterclaims
 * [cm delete clusterpool](cm_delete_clusterpool.md)	 - Delete clusterpools

--- a/docs/help/cm_delete.md
+++ b/docs/help/cm_delete.md
@@ -49,7 +49,7 @@ delete a resource
 
 ### SEE ALSO
 
-* [cm](cm.md)	 - CLI for Open Cluster Management
+* [cm](cm.md)	 - CLI for Red Hat Advanced Cluster Management
 * [cm delete cluster](cm_delete_cluster.md)	 - Delete a cluster
 * [cm delete clusterclaim](cm_delete_clusterclaim.md)	 - Delete clusterclaims
 * [cm delete clusterpool](cm_delete_clusterpool.md)	 - Delete clusterpools

--- a/docs/help/cm_detach.md
+++ b/docs/help/cm_detach.md
@@ -49,6 +49,6 @@ detach a resources
 
 ### SEE ALSO
 
-* [cm](cm.md)	 - CLI for Open Cluster Management
+* [cm](cm.md)	 - CLI for Red Hat Advanced Cluster Management
 * [cm detach cluster](cm_detach_cluster.md)	 - detach a cluster
 

--- a/docs/help/cm_detach.md
+++ b/docs/help/cm_detach.md
@@ -49,6 +49,6 @@ detach a resources
 
 ### SEE ALSO
 
-* [cm](cm.md)	 - CLI for Red Hat Advanced Clust Management
+* [cm](cm.md)	 - CLI for Open Cluster Management
 * [cm detach cluster](cm_detach_cluster.md)	 - detach a cluster
 

--- a/docs/help/cm_enable.md
+++ b/docs/help/cm_enable.md
@@ -49,6 +49,6 @@ enable a feature
 
 ### SEE ALSO
 
-* [cm](cm.md)	 - CLI for Red Hat Advanced Clust Management
+* [cm](cm.md)	 - CLI for Open Cluster Management
 * [cm enable addons](cm_enable_addons.md)	 - Import a cluster
 

--- a/docs/help/cm_enable.md
+++ b/docs/help/cm_enable.md
@@ -49,6 +49,6 @@ enable a feature
 
 ### SEE ALSO
 
-* [cm](cm.md)	 - CLI for Open Cluster Management
+* [cm](cm.md)	 - CLI for Red Hat Advanced Cluster Management
 * [cm enable addons](cm_enable_addons.md)	 - Import a cluster
 

--- a/docs/help/cm_get.md
+++ b/docs/help/cm_get.md
@@ -49,7 +49,7 @@ get a resource
 
 ### SEE ALSO
 
-* [cm](cm.md)	 - CLI for Open Cluster Management
+* [cm](cm.md)	 - CLI for Red Hat Advanced Cluster Management
 * [cm get clusterclaims](cm_get_clusterclaims.md)	 - Display clusterclaims
 * [cm get clusterpoolhosts](cm_get_clusterpoolhosts.md)	 - list the clusterpoolhosts
 * [cm get clusterpools](cm_get_clusterpools.md)	 - Get clusterpool

--- a/docs/help/cm_get.md
+++ b/docs/help/cm_get.md
@@ -49,7 +49,7 @@ get a resource
 
 ### SEE ALSO
 
-* [cm](cm.md)	 - CLI for Red Hat Advanced Clust Management
+* [cm](cm.md)	 - CLI for Open Cluster Management
 * [cm get clusterclaims](cm_get_clusterclaims.md)	 - Display clusterclaims
 * [cm get clusterpoolhosts](cm_get_clusterpoolhosts.md)	 - list the clusterpoolhosts
 * [cm get clusterpools](cm_get_clusterpools.md)	 - Get clusterpool

--- a/docs/help/cm_hibernate.md
+++ b/docs/help/cm_hibernate.md
@@ -49,6 +49,6 @@ hibernate a resource
 
 ### SEE ALSO
 
-* [cm](cm.md)	 - CLI for Open Cluster Management
+* [cm](cm.md)	 - CLI for Red Hat Advanced Cluster Management
 * [cm hibernate clusterclaim](cm_hibernate_clusterclaim.md)	 - hibernate clusterclaims
 

--- a/docs/help/cm_hibernate.md
+++ b/docs/help/cm_hibernate.md
@@ -49,6 +49,6 @@ hibernate a resource
 
 ### SEE ALSO
 
-* [cm](cm.md)	 - CLI for Red Hat Advanced Clust Management
+* [cm](cm.md)	 - CLI for Open Cluster Management
 * [cm hibernate clusterclaim](cm_hibernate_clusterclaim.md)	 - hibernate clusterclaims
 

--- a/docs/help/cm_init.md
+++ b/docs/help/cm_init.md
@@ -65,5 +65,5 @@ cm init
 
 ### SEE ALSO
 
-* [cm](cm.md)	 - CLI for Open Cluster Management
+* [cm](cm.md)	 - CLI for Red Hat Advanced Cluster Management
 

--- a/docs/help/cm_init.md
+++ b/docs/help/cm_init.md
@@ -65,5 +65,5 @@ cm init
 
 ### SEE ALSO
 
-* [cm](cm.md)	 - CLI for Red Hat Advanced Clust Management
+* [cm](cm.md)	 - CLI for Open Cluster Management
 

--- a/docs/help/cm_join.md
+++ b/docs/help/cm_join.md
@@ -66,5 +66,5 @@ cm join --hub-token <tokenID.tokenSecret> --hub-apiserver <hub_apiserveR_url> --
 
 ### SEE ALSO
 
-* [cm](cm.md)	 - CLI for Red Hat Advanced Clust Management
+* [cm](cm.md)	 - CLI for Open Cluster Management
 

--- a/docs/help/cm_join.md
+++ b/docs/help/cm_join.md
@@ -66,5 +66,5 @@ cm join --hub-token <tokenID.tokenSecret> --hub-apiserver <hub_apiserveR_url> --
 
 ### SEE ALSO
 
-* [cm](cm.md)	 - CLI for Open Cluster Management
+* [cm](cm.md)	 - CLI for Red Hat Advanced Cluster Management
 

--- a/docs/help/cm_options.md
+++ b/docs/help/cm_options.md
@@ -64,5 +64,5 @@ cm options [flags]
 
 ### SEE ALSO
 
-* [cm](cm.md)	 - CLI for Red Hat Advanced Clust Management
+* [cm](cm.md)	 - CLI for Open Cluster Management
 

--- a/docs/help/cm_options.md
+++ b/docs/help/cm_options.md
@@ -64,5 +64,5 @@ cm options [flags]
 
 ### SEE ALSO
 
-* [cm](cm.md)	 - CLI for Open Cluster Management
+* [cm](cm.md)	 - CLI for Red Hat Advanced Cluster Management
 

--- a/docs/help/cm_plugin.md
+++ b/docs/help/cm_plugin.md
@@ -61,6 +61,6 @@ cm plugin [flags]
 
 ### SEE ALSO
 
-* [cm](cm.md)	 - CLI for Red Hat Advanced Clust Management
+* [cm](cm.md)	 - CLI for Open Cluster Management
 * [cm plugin list](cm_plugin_list.md)	 - list all visible plugin executables on a user's PATH
 

--- a/docs/help/cm_plugin.md
+++ b/docs/help/cm_plugin.md
@@ -61,6 +61,6 @@ cm plugin [flags]
 
 ### SEE ALSO
 
-* [cm](cm.md)	 - CLI for Open Cluster Management
+* [cm](cm.md)	 - CLI for Red Hat Advanced Cluster Management
 * [cm plugin list](cm_plugin_list.md)	 - list all visible plugin executables on a user's PATH
 

--- a/docs/help/cm_run.md
+++ b/docs/help/cm_run.md
@@ -49,6 +49,6 @@ run a resource
 
 ### SEE ALSO
 
-* [cm](cm.md)	 - CLI for Red Hat Advanced Clust Management
+* [cm](cm.md)	 - CLI for Open Cluster Management
 * [cm run clusterclaim](cm_run_clusterclaim.md)	 - Run clusterclaims
 

--- a/docs/help/cm_run.md
+++ b/docs/help/cm_run.md
@@ -49,6 +49,6 @@ run a resource
 
 ### SEE ALSO
 
-* [cm](cm.md)	 - CLI for Open Cluster Management
+* [cm](cm.md)	 - CLI for Red Hat Advanced Cluster Management
 * [cm run clusterclaim](cm_run_clusterclaim.md)	 - Run clusterclaims
 

--- a/docs/help/cm_scale.md
+++ b/docs/help/cm_scale.md
@@ -49,7 +49,7 @@ scale a resource
 
 ### SEE ALSO
 
-* [cm](cm.md)	 - CLI for Open Cluster Management
+* [cm](cm.md)	 - CLI for Red Hat Advanced Cluster Management
 * [cm scale cluster](cm_scale_cluster.md)	 - Scale a cluster
 * [cm scale clusterpool](cm_scale_clusterpool.md)	 - Scale clusterpool
 

--- a/docs/help/cm_scale.md
+++ b/docs/help/cm_scale.md
@@ -49,7 +49,7 @@ scale a resource
 
 ### SEE ALSO
 
-* [cm](cm.md)	 - CLI for Red Hat Advanced Clust Management
+* [cm](cm.md)	 - CLI for Open Cluster Management
 * [cm scale cluster](cm_scale_cluster.md)	 - Scale a cluster
 * [cm scale clusterpool](cm_scale_clusterpool.md)	 - Scale clusterpool
 

--- a/docs/help/cm_set.md
+++ b/docs/help/cm_set.md
@@ -49,6 +49,6 @@ set a resource
 
 ### SEE ALSO
 
-* [cm](cm.md)	 - CLI for Red Hat Advanced Clust Management
+* [cm](cm.md)	 - CLI for Open Cluster Management
 * [cm set clusterpoolhost](cm_set_clusterpoolhost.md)	 - set cph makes the given clusterpoolhost active/current
 

--- a/docs/help/cm_set.md
+++ b/docs/help/cm_set.md
@@ -49,6 +49,6 @@ set a resource
 
 ### SEE ALSO
 
-* [cm](cm.md)	 - CLI for Open Cluster Management
+* [cm](cm.md)	 - CLI for Red Hat Advanced Cluster Management
 * [cm set clusterpoolhost](cm_set_clusterpoolhost.md)	 - set cph makes the given clusterpoolhost active/current
 

--- a/docs/help/cm_use.md
+++ b/docs/help/cm_use.md
@@ -49,7 +49,7 @@ use a resource
 
 ### SEE ALSO
 
-* [cm](cm.md)	 - CLI for Open Cluster Management
+* [cm](cm.md)	 - CLI for Red Hat Advanced Cluster Management
 * [cm use clusterclaim](cm_use_clusterclaim.md)	 - use clusterclaim change the current context to a cluster claim
 * [cm use clusterpoolhost](cm_use_clusterpoolhost.md)	 - use cph change the current context to a clusterpoolhost
 

--- a/docs/help/cm_use.md
+++ b/docs/help/cm_use.md
@@ -49,7 +49,7 @@ use a resource
 
 ### SEE ALSO
 
-* [cm](cm.md)	 - CLI for Red Hat Advanced Clust Management
+* [cm](cm.md)	 - CLI for Open Cluster Management
 * [cm use clusterclaim](cm_use_clusterclaim.md)	 - use clusterclaim change the current context to a cluster claim
 * [cm use clusterpoolhost](cm_use_clusterpoolhost.md)	 - use cph change the current context to a clusterpoolhost
 

--- a/docs/help/cm_version.md
+++ b/docs/help/cm_version.md
@@ -62,5 +62,5 @@ cm version
 
 ### SEE ALSO
 
-* [cm](cm.md)	 - CLI for Open Cluster Management
+* [cm](cm.md)	 - CLI for Red Hat Advanced Cluster Management
 

--- a/docs/help/cm_version.md
+++ b/docs/help/cm_version.md
@@ -62,5 +62,5 @@ cm version
 
 ### SEE ALSO
 
-* [cm](cm.md)	 - CLI for Red Hat Advanced Clust Management
+* [cm](cm.md)	 - CLI for Open Cluster Management
 

--- a/docs/help/cm_with.md
+++ b/docs/help/cm_with.md
@@ -49,6 +49,6 @@ execute a command on a specific cluster
 
 ### SEE ALSO
 
-* [cm](cm.md)	 - CLI for Red Hat Advanced Clust Management
+* [cm](cm.md)	 - CLI for Open Cluster Management
 * [cm with clusterclaim](cm_with_clusterclaim.md)	 - with clusterclaim executes a kubernetes command using the clusterclaim context
 

--- a/docs/help/cm_with.md
+++ b/docs/help/cm_with.md
@@ -49,6 +49,6 @@ execute a command on a specific cluster
 
 ### SEE ALSO
 
-* [cm](cm.md)	 - CLI for Open Cluster Management
+* [cm](cm.md)	 - CLI for Red Hat Advanced Cluster Management
 * [cm with clusterclaim](cm_with_clusterclaim.md)	 - with clusterclaim executes a kubernetes command using the clusterclaim context
 

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -43,7 +43,7 @@ import (
 func NewCMCommand() *cobra.Command {
 	root := &cobra.Command{
 		Use:   "cm",
-		Short: "CLI for Red Hat Advanced Cluster Management",
+		Short: "CLI for Open Cluster Management",
 		//This remove the auto-generated tag in the cobra doc
 		DisableAutoGenTag: true,
 	}

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -43,7 +43,7 @@ import (
 func NewCMCommand() *cobra.Command {
 	root := &cobra.Command{
 		Use:   "cm",
-		Short: "CLI for Open Cluster Management",
+		Short: "CLI for Red Hat Advanced Cluster Management",
 		//This remove the auto-generated tag in the cobra doc
 		DisableAutoGenTag: true,
 	}

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -43,7 +43,7 @@ import (
 func NewCMCommand() *cobra.Command {
 	root := &cobra.Command{
 		Use:   "cm",
-		Short: "CLI for Red Hat Advanced Clust Management",
+		Short: "CLI for Red Hat Advanced Cluster Management",
 		//This remove the auto-generated tag in the cobra doc
 		DisableAutoGenTag: true,
 	}


### PR DESCRIPTION
~I wasn't sure whether we needed to remove "Red Hat" to match the README or whether this change could be confusing, but I thought I'd put this out there in case.~ Edit: Not needed since we have `clusteradm`. Reduced to fixing missing "er"